### PR TITLE
Remove unnecessary `mut` modifiers from TX_BUFFER and RX_BUFFER declarations

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -28,9 +28,9 @@ pub const DMA_BUFFER_LENGTH: usize = HALF_DMA_BUFFER_LENGTH * 2; //  2 half-bloc
 
 //DMA buffer must be in special region. Refer https://embassy.dev/book/#_stm32_bdma_only_working_out_of_some_ram_regions
 #[link_section = ".sram1_bss"]
-static mut TX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
+static TX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
 #[link_section = ".sram1_bss"]
-static mut RX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
+static RX_BUFFER: GroundedArrayCell<u32, DMA_BUFFER_LENGTH> = GroundedArrayCell::uninit();
 
 // - types --------------------------------------------------------------------
 

--- a/src/codec/wm8731.rs
+++ b/src/codec/wm8731.rs
@@ -11,7 +11,7 @@ pub struct Codec {}
 
 impl Codec {
     //====================wm8731 register set up functions============================
-    pub async fn setup_wm8731<'a>(i2c: &mut hal::i2c::I2c<'a, hal::mode::Blocking>, fs: Fs) {
+    pub async fn setup_wm8731(i2c: &mut hal::i2c::I2c<'_, hal::mode::Blocking>, fs: Fs) {
         use wm8731::WM8731;
         info!("setup wm8731 from I2C");
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -55,7 +55,7 @@ pub struct Flash<'a> {
     qspi: Qspi<'a, QUADSPI, Blocking>,
 }
 
-impl<'a> Flash<'a> {
+impl Flash<'_> {
     pub fn read(&mut self, address: u32, buffer: &mut [u8]) {
         assert!(address <= MAX_ADDRESS);
 

--- a/src/led.rs
+++ b/src/led.rs
@@ -2,7 +2,7 @@ use embassy_stm32 as hal;
 use hal::gpio::{self, Speed};
 pub struct UserLed<'a>(gpio::Output<'a>);
 
-impl<'a> UserLed<'a> {
+impl UserLed<'_> {
     pub fn new(pin: hal::peripherals::PC7) -> Self {
         Self(gpio::Output::new(pin, gpio::Level::Low, Speed::Low))
     }


### PR DESCRIPTION
Eliminate the `mut` modifiers from the declarations of `TX_BUFFER` and `RX_BUFFER` to suppress warnings about creating shared references to mutable statics. This change enhances safety and aligns with best practices in Rust. Fixes #27