### PR TITLE
Make overrun recoverable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ seed = []
 seed_1_1 = []
 seed_1_2 = []
 patch_sm = []
+panic_on_overrun = []
 # defmt = []
 
 [patch.crates-io]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,5 +1,4 @@
 use crate::codec::{Codec, Pins as CodecPins};
-use defmt::error;
 use defmt::info;
 use defmt::unwrap;
 use embassy_stm32 as hal;
@@ -16,6 +15,9 @@ use hal::{
         TxRx,
     },
 };
+
+#[cfg(not(feature = "panic_on_overrun"))]
+use defmt::error;
 
 // - global constants ---------------------------------------------------------
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -208,7 +208,7 @@ impl<'a> Interface<'a> {
         let mut read_buf = [0; HALF_DMA_BUFFER_LENGTH];
         loop {
             #[cfg(not(feature = "panic_on_overrun"))]
-            unwrap!(self.sai_rx.read(&mut read_buf).await.map_err(|e| {
+            unwrap!(self.sai_rx.read(&mut read_buf).await.or_else(|e| {
                 match e {
                     sai::Error::Overrun => {
                         error!("Overrun on audio buffer read");
@@ -224,10 +224,10 @@ impl<'a> Interface<'a> {
             callback(&read_buf, &mut write_buf);
 
             #[cfg(not(feature = "panic_on_overrun"))]
-            unwrap!(self.sai_tx.write(&write_buf).await.map_err(|e| {
+            unwrap!(self.sai_tx.write(&write_buf).await.or_else(|e| {
                 match e {
                     sai::Error::Overrun => {
-                        error!("Overrun on audio buffer read");
+                        error!("Overrun on audio buffer write");
                         Ok(())
                     }
                     e => Err(e),

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -219,7 +219,7 @@ impl<'a> Interface<'a> {
             }));
 
             #[cfg(feature = "panic_on_overrun")]
-            unwrap!(self.sai_tx.read(&write_buf).await);
+            unwrap!(self.sai_rx.read(&mut read_buf).await);
 
             callback(&read_buf, &mut write_buf);
 


### PR DESCRIPTION
- fixed #30
- added "panic_on_overrun" feature to regain panicking behavior

the error messages could maybe still be improved so i am open to suggestions.
The default behavior (at the moment its not panicking on overrun) could be flipped around as well if requested.